### PR TITLE
add missing callback so will work with node-resque 3.0

### DIFF
--- a/lib/rider.js
+++ b/lib/rider.js
@@ -24,7 +24,11 @@ var rider = function(options, jobs){
     }
   }
 
-  this.bus.connect(function(){ });
+  this.bus.connect(function(error) { 
+    if (error) {
+      throw error;
+    }
+  });
   var self = this;
   this.bus.on('error', function(error){
     self.emit(error);

--- a/lib/rider.js
+++ b/lib/rider.js
@@ -24,7 +24,7 @@ var rider = function(options, jobs){
     }
   }
 
-  this.bus.connect();
+  this.bus.connect(function(){ });
   var self = this;
   this.bus.on('error', function(error){
     self.emit(error);


### PR DESCRIPTION
I tried upgrading to node-resque 3.0.4 and I received a `Uncaught TypeError: callback is not a function
 at node_modules/node-resque/lib/connection.js:76:20`.  Eventually traced it back to this call to bus.connect(). Added an empty function just to provide a callback, and that seemed to do what I expected. Not sure if there's a more elegant way to handle this. I was going to throw in a console.log to help debug output but I figured not everyone using this wants their logs cluttered with such a message.